### PR TITLE
Return value from required and assert

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,11 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## 0.2.2 - 2018-01-17
+### Changed
+- .required and .assert throw a `ReferenceError` if given key is missing from `process.env` and return given key's value from `process.env` otherwise.
+- switch from `faucet` to `tap-spec`.
+
 ## 0.2.0 - 2014-12-15
 ### Added
 - .contains (alias for .has)

--- a/index.js
+++ b/index.js
@@ -1,33 +1,33 @@
-'use strict';
+'use strict'
 
 /*!
  * imports.
  */
 
-var format = require('util').format;
+var format = require('util').format
 
 /*!
  * exports.
  */
 
-exports.assert = required;
-exports.contains = has;
-exports.del = del;
-exports.get = get;
-exports.has = has;
-exports.missing = missing;
-exports.put = set;
-exports.required = required;
-exports.set = set;
+exports.assert = required
+exports.contains = has
+exports.del = del
+exports.get = get
+exports.has = has
+exports.missing = missing
+exports.put = set
+exports.required = required
+exports.set = set
 
 /*!
  * init.
  */
 
-var requireError = 'Missing required environment variable "%s"';
+var REQUIRED_ERROR = 'Missing required environment variable "%s"'
 
 /**
- * Thows a `ReferenceError` if given key is missing from `process.env`.
+ * Throw a `ReferenceError` if given key is missing from `process.env` and return given key's value from `process.env` otherwise.
  * aliases: assert
  *
  * @param {String} key
@@ -36,8 +36,12 @@ var requireError = 'Missing required environment variable "%s"';
  * @throws {ReferenceError}
  */
 
-function required(key) {
-  if (missing(key)) throw new ReferenceError(format(requireError, key));
+function required (key) {
+  if (missing(key)) {
+    throw new ReferenceError(format(REQUIRED_ERROR, key))
+  } else {
+    return get(key)
+  }
 }
 
 /**
@@ -48,8 +52,8 @@ function required(key) {
  * @api public
  */
 
-function get(key) {
-  return process.env[key];
+function get (key) {
+  return process.env[key]
 }
 
 /**
@@ -61,9 +65,9 @@ function get(key) {
  * @api public
  */
 
-function set(dictionary) {
+function set (dictionary) {
   for (var key in dictionary) {
-    if (missing(key)) process.env[key] = dictionary[key];
+    if (missing(key)) process.env[key] = dictionary[key]
   }
 }
 
@@ -74,8 +78,8 @@ function set(dictionary) {
  * @api public
  */
 
-function del(key) {
-  delete process.env[key];
+function del (key) {
+  delete process.env[key]
 }
 
 /**
@@ -87,8 +91,8 @@ function del(key) {
  * @api public
  */
 
-function has(key) {
-  return process.env.hasOwnProperty(key);
+function has (key) {
+  return process.env.hasOwnProperty(key)
 }
 
 /**
@@ -99,6 +103,6 @@ function has(key) {
  * @api public
  */
 
-function missing(key) {
-  return !has(key);
+function missing (key) {
+  return !has(key)
 }

--- a/package.json
+++ b/package.json
@@ -1,25 +1,56 @@
 {
   "name": "env-accessors",
-  "version": "0.2.1",
-  "keywords": [
-    "accessors",
-    "accessor",
-    "env",
-    "envc",
-    "environments",
-    "environment",
-    "variables",
-    "variable",
-    "12factor"
-  ],
   "description": "process.env accessor functions.",
+  "version": "0.2.1",
   "author": "Wil Moore III <wil.moore@wilmoore.com>",
+  "bugs": {
+    "url": "https://github.com/wilmoore/node-env-accessors/issues"
+  },
+  "config": {},
   "contributors": [
     {
       "name": "Wil Moore III",
       "email": "wil.moore@wilmoore.com"
     }
   ],
+  "dependencies": {},
+  "devDependencies": {
+    "envc": "^2.0.0",
+    "rerun-script": "^0.4.1",
+    "standard": "*",
+    "tap-spec": "^4.1.1",
+    "tape": "^3.0.3"
+  },
+  "files": [
+    "*.json",
+    "*.js",
+    "license",
+    "readme.md"
+  ],
+  "homepage": "https://github.com/wilmoore/node-env-accessors",
+  "keywords": [
+    "12factor",
+    "accessor",
+    "accessors",
+    "env",
+    "envc",
+    "environment",
+    "environments",
+    "variable",
+    "variables"
+  ],
+  "license": "MIT",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/wilmoore/node-env-accessors"
+  },
+  "scripts": {
+    "lint": "standard",
+    "postversion": "git push --follow-tags && npm publish",
+    "test": "node test.js test/**/*.js | tap-spec",
+    "watch": "rerun-script"
+  },
   "watches": [
     {
       "script": "test",
@@ -37,34 +68,5 @@
         "test/**/*.js"
       ]
     }
-  ],
-  "scripts": {
-    "lint": "jshint *.js",
-    "test": "node test.js test/**/*.js | faucet",
-    "watch": "rerun-script"
-  },
-  "files": [
-    "*.json",
-    "*.js",
-    "license",
-    "readme.md"
-  ],
-  "main": "index.js",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/wilmoore/node-env-accessors"
-  },
-  "bugs": {
-    "url": "https://github.com/wilmoore/node-env-accessors/issues"
-  },
-  "devDependencies": {
-    "envc": "^2.0.0",
-    "faucet": "0.0.1",
-    "jshint": "^2.5.10",
-    "rerun-script": "^0.4.1",
-    "tape": "^3.0.3"
-  },
-  "dependencies": {},
-  "config": {},
-  "license": "MIT"
+  ]
 }

--- a/readme.md
+++ b/readme.md
@@ -44,7 +44,7 @@ Whether given key is missing from `process.env`.
 
 > aliases: assert
 
-Thows a `ReferenceError` if given key is missing from `process.env`.
+Throw a `ReferenceError` if given key is missing from `process.env` and return given key's value from `process.env` otherwise.
 
     required('NEW_RELIC_LICENSE_KEY');
 

--- a/test.js
+++ b/test.js
@@ -1,58 +1,58 @@
-'use strict';
+'use strict'
 
 /*!
  * imports.
  */
 
-var envc = require('envc');
-var test = require('tape');
+var envc = require('envc')
+var test = require('tape')
 
 /*!
  * imports (local).
  */
 
-var del = require('./').del;
-var get = require('./').get;
-var has = require('./').has;
-var missing = require('./').missing;
-var required = require('./').required;
-var set = require('./').set;
+var del = require('./').del
+var get = require('./').get
+var has = require('./').has
+var missing = require('./').missing
+var required = require('./').required
+var set = require('./').set
 
 /*!
  * helpers.
  */
 
-var envs = {};
-var testKey = 'TEST_ENV_ACCESSORS_KEY';
-var testVal = 'test-env-accessors-val';
+var envs = {}
+var testKey = 'TEST_ENV_ACCESSORS_KEY'
+var testVal = 'test-env-accessors-val'
 
 /**
  * inject variables.
  */
 
-function inject() {
-  envs = envc();
+function inject () {
+  envs = envc()
 }
 
 /**
  * reset variables.
  */
 
-function reset() {
-  var key;
+function reset () {
+  var key
 
-  for (key in envs) delete process.env[envs[key]];
-  for (key in fixture()) delete process.env[key];
+  for (key in envs) delete process.env[envs[key]]
+  for (key in fixture()) delete process.env[key]
 }
 
 /**
  * produce fixture(s).
  */
 
-function fixture() {
-  var out = {};
-  out[testKey] = testVal;
-  return out;
+function fixture () {
+  var out = {}
+  out[testKey] = testVal
+  return out
 }
 
 /*!
@@ -60,46 +60,55 @@ function fixture() {
  */
 
 test('.get()', function (t) {
-  t.plan(1);
-  inject();
-  t.equal(get('TEST_FIXTURE_LOADED'), 'YES');
-  reset();
-});
+  t.plan(1)
+  inject()
+  t.equal(get('TEST_FIXTURE_LOADED'), 'YES')
+  reset()
+})
 
 test('.has()', function (t) {
-  t.plan(1);
-  inject();
-  t.assert(has('TEST_FIXTURE_LOADED'));
-  reset();
-});
+  t.plan(1)
+  inject()
+  t.assert(has('TEST_FIXTURE_LOADED'))
+  reset()
+})
 
 test('.missing', function (t) {
-  t.plan(1);
-  t.assert(missing(testKey));
-});
+  t.plan(1)
+  t.assert(missing(testKey))
+})
 
 test('.set', function (t) {
-  t.plan(1);
-  set(fixture());
-  t.equal(process.env[testKey], testVal);
-  reset();
-});
+  t.plan(1)
+  set(fixture())
+  t.equal(process.env[testKey], testVal)
+  reset()
+})
 
-test('.required', function (t) {
-  t.plan(1);
+test('.required (unset)', function (t) {
+  t.plan(1)
 
   try {
-    required(testKey);
+    required(testKey)
   } catch (e) {
-    console.log(e.name);
-    t.equal(e.constructor, ReferenceError);
+    t.equal(e.constructor, ReferenceError)
   }
-});
+})
+
+test('.required (set)', function (t) {
+  t.plan(1)
+  inject()
+  try {
+    t.equal(required('TEST_FIXTURE_LOADED'), 'YES')
+  } catch (e) {
+    t.fail(e.message)
+  }
+})
 
 test('.del()', function (t) {
-  t.plan(1);
-  set(fixture());
-  del(testKey);
-  t.equal(process.env[testKey], undefined);
-  reset();
-});
+  t.plan(1)
+  set(fixture())
+  del(testKey)
+  t.equal(process.env[testKey], undefined)
+  reset()
+})


### PR DESCRIPTION
Fixes #1

- updates `required` and `assert` function to throw a `ReferenceError` if given key is missing from `process.env` and return given key's value from `process.env` otherwise.